### PR TITLE
Set LANG=en in parse_git_dirty

### DIFF
--- a/js/easyprompt.js
+++ b/js/easyprompt.js
@@ -82,6 +82,7 @@ var elements = {
             "}\n\n"+
             "# get current status of git repo\n"+
             "function parse_git_dirty {\n"+
+            "\tLANG=en\n"+
             "\tstatus=`git status 2>&1 | tee`\n"+
             "\tdirty=`echo -n \"${status}\" 2> /dev/null | grep \"modified:\" &> /dev/null; echo \"$?\"`\n"+
             "\tuntracked=`echo -n \"${status}\" 2> /dev/null | grep \"Untracked files\" &> /dev/null; echo \"$?\"`\n"+


### PR DESCRIPTION
The function `parse_git_dirty` needs the output of `git status` to be in
english. This means to lose information in the git status of your prompt if
git speaks to you in a different language.

For example a `git status` output could be the following in german:

    Auf Branch master
    Ihr Branch ist auf dem selben Stand wie 'origin/master'.
    zum Commit vorgemerkte Änderungen:
      (benutzen Sie "git reset HEAD <Datei>..." zum Entfernen aus der Staging-Area)

    geändert:       js/easyprompt.js

To force git to speak english you can set `LANG=en` in the function
`parse_git_dirty` before `git status` is called. This modification of `LANG`
is just local. The user will still get the output in his language when he calls
`git status` by himself.